### PR TITLE
give more power to isCollapsed

### DIFF
--- a/lib/components/measure.js
+++ b/lib/components/measure.js
@@ -82,7 +82,7 @@ const measure: MeasureType = ({ getId, Component, isCollapsed = true }) => {
       }
     }
     groupStart(hasChanges, ...args) {
-      if (hasChanges && isCollapsed) {
+      if (isCollapsed) {
         console.groupCollapsed(...args)
         return
       }


### PR DESCRIPTION
Basically,  currently `isCollapsed` is not being used in every case: this means that when there's no change in the render it will still print not collapsed. 

In some scenarios where I need to measure an highly used component this creates a lot of noise, so I'd like to be able to collapse in any case.