### PR TITLE
Fix for case when _debugOwner is null

### DIFF
--- a/lib/components/measure.js
+++ b/lib/components/measure.js
@@ -134,7 +134,8 @@ const INITIAL_ITEM_KEYS = {
 
 const createRecordItem = ({ element, componentName }) => {
   // $FlowFixMe
-  const ownerName = element._reactInternalFiber._debugOwner.type.name
+  const owner = element._reactInternalFiber._debugOwner;
+  const ownerName = (owner !== null && typeof owner !== 'undefined') ? element._reactInternalFiber._debugOwner.type.name : "";
   const recordIdentifier = `${componentName}: ${element.identifier}`
   record[recordIdentifier] = {
     'Owner > component': `${ownerName} > ${componentName}`,


### PR DESCRIPTION
Check for the same came in following code:
 https://github.com/gaearon/react/blob/0a67baa9593b9c520cd875e6e466368b10456a9b/src/renderers/shared/fiber/ReactDebugCurrentFiber.js#L33