### PR TITLE
Updating the connect function to reflect an updated react-redux api

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -8,6 +8,8 @@ import measure from './components/measure'
 type ConnectType = ({
   mapStateToProps?: Function,
   mapDispatchToProps?: Function,
+  mergeProps?: Function,
+  options?: Object,
   getId: string | Object => string,
   Component: React.ComponentType<*>,
   isCollapsed?: boolean,
@@ -16,10 +18,12 @@ type ConnectType = ({
 const connect: ConnectType = ({
   mapStateToProps,
   mapDispatchToProps,
+  mergeProps,
+  options,
   getId,
   Component,
   isCollapsed,
-}) => ReactRedux.connect(mapStateToProps, mapDispatchToProps)(
+}) => ReactRedux.connect(mapStateToProps, mapDispatchToProps, mergeProps, options)(
   measure({ getId, Component, isCollapsed })
 )
 


### PR DESCRIPTION
I think the change is pretty self-explanatory.

The react-redux api can be found here: https://github.com/reduxjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options